### PR TITLE
#16: Fix: Modified mock unit test that threw a null pointer exception…

### DIFF
--- a/service/src/test/java/be/bencouwberghs/timeless_songs/service/BandServiceImplTest.java
+++ b/service/src/test/java/be/bencouwberghs/timeless_songs/service/BandServiceImplTest.java
@@ -65,6 +65,8 @@ class BandServiceImplTest {
             setLinkWikiPage("Testlink4");
         }};
 
+        when(bandRepository.findByName(band4.getName())).thenReturn(band4);
+
         bandService.modifyBand(band4);
 
         verify(bandRepository).save(band4);


### PR DESCRIPTION
Okay I forgot to verify the unit tests and only did integration tests so I didn't catch this when I changed modifyBand method. Line of code mocks that the band entity is in our db and returns said entity so that modifyBand call works fine.